### PR TITLE
fix: publish homebrew formula under Formula/ directory

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,6 +40,7 @@ brews:
   - name: sql-tap
     homepage: https://github.com/mickamy/sql-tap
     description: Watch SQL traffic in real-time with a TUI
+    directory: Formula
     install: |
       bin.install "sql-tap"
       bin.install "sql-tapd"


### PR DESCRIPTION
## Problem

`brew install mickamy/tap/sql-tap` failed to pick up the latest release. The GoReleaser `brews` block wrote the formula to the tap repository root (`sql-tap.rb`) instead of the `Formula/` directory. Recent Homebrew only recognizes formulae under `Formula/`, so the root file was invisible and installs fell back to a stale cask (later removed) or failed outright.

## Fix

Add `directory: Formula` to the `brews` block so GoReleaser publishes to `Formula/sql-tap.rb`, matching the other formulae in `mickamy/homebrew-tap` (e.g., `seeder`, `subset`).

## Notes

The current release (`v0.3.1`) has already been relocated to `Formula/sql-tap.rb` in the tap by hand, so `brew install mickamy/tap/sql-tap` works now. This change makes future releases land there automatically.
